### PR TITLE
Add submission timestamp feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Extension that adds reddit comments to YouTube
 - Change any default settings in the options
 - Available on [Chrome](https://chrome.google.com/webstore/detail/threads-for-youtube/npbmhogimiolmklafhlpbifkjinoadkh) & [Firefox](https://addons.mozilla.org/en-US/firefox/addon/threads-for-youtube/)
 
+### Upcoming Features
+
+- [Easily go to each post's linked timestamp (if present)](https://github.com/a-bravo/threads-for-youtube/pull/9)
+
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](/CONTRIBUTING.md).

--- a/src/components/Submission.vue
+++ b/src/components/Submission.vue
@@ -7,6 +7,15 @@
     >
       - {{ submission.link_flair_text }}
     </span>
+    <span>
+      <a
+        v-if="timestamp"
+        :class="YT_LINK_CLASS"
+        @click="goToTimeStamp()"
+      >
+        (@{{ toHHMMSS(timestamp) }})
+      </a>
+    </span>
     <br>
     <span class="details">
       <span
@@ -77,14 +86,25 @@
 <script>
 import AwardsShelf from './AwardsShelf.vue';
 import authorStatusMixin from '../mixins/authorStatusMixin';
-import { timeAgo, pluralize } from '../util';
-import { YT_LINK_CLASS, RT_BASE_URL } from '../constants';
+import scrollToMixin from '../mixins/scrollToMixin';
+import {
+  timeAgo,
+  pluralize,
+  toHHMMSS,
+  parseFormattedTime,
+} from '../util';
+import {
+  YT_LINK_CLASS,
+  RT_BASE_URL,
+  YT_VIDEO_TAG,
+  YT_VIDEO_ID,
+} from '../constants';
 
 export default {
   components: {
     AwardsShelf,
   },
-  mixins: [authorStatusMixin],
+  mixins: [authorStatusMixin, scrollToMixin],
   props: {
     submission: {
       type: Object,
@@ -99,6 +119,7 @@ export default {
     return {
       YT_LINK_CLASS,
       RT_BASE_URL,
+      timestamp: this.setTimeStamp(),
     };
   },
   computed: {
@@ -109,6 +130,25 @@ export default {
   methods: {
     timeAgo,
     pluralize,
+    toHHMMSS,
+    setTimeStamp() {
+      // if the video does not exist, ignore the timestamp
+      if (!document.querySelector(YT_VIDEO_TAG)) {
+        return null;
+      }
+
+      // get timestamp from url
+      const url = new URL(this.submission.url);
+      const time = url.searchParams.get('t');
+
+      return time ? parseFormattedTime(time) : null;
+    },
+    goToTimeStamp() {
+      const player = document.querySelector(YT_VIDEO_TAG);
+      player.currentTime = this.timestamp;
+      player.play();
+      this.scrollTo(YT_VIDEO_ID);
+    },
   },
 };
 </script>

--- a/src/components/Submission.vue
+++ b/src/components/Submission.vue
@@ -7,9 +7,8 @@
     >
       - {{ submission.link_flair_text }}
     </span>
-    <span>
+    <span v-if="timestamp">
       <a
-        v-if="timestamp"
         :class="YT_LINK_CLASS"
         @click="goToTimeStamp()"
       >

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -55,6 +55,9 @@ export const COMMENT_SORTS = [
 export const YT_COMMENTS_ID = 'comments';
 export const YT_NAVBAR_ID = 'masthead';
 
+export const YT_VIDEO_TAG = 'video';
+export const YT_VIDEO_ID = 'movie_player';
+
 export const YT_LINK_CLASS = 'yt-simple-endpoint';
 export const YT_CONTENT_RENDERER_CLASS = 'ytd-comment-renderer';
 

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -1,5 +1,5 @@
 /**
- * @file Makes utc timestamps human readable
+ * @file Various util functions
  */
 
 // Constants
@@ -29,6 +29,7 @@ export function pluralize(amount, unit, pluralUnit = `${unit}s`) {
 
 /**
  * Formats the relative time
+ * Makes utc timestamps human readable
  *
  * @param {Number} time The utc value
  *
@@ -61,6 +62,41 @@ export function timeAgo(time) {
   }
 
   return `${readableTime} ${unit}`;
+}
+
+/**
+ * Convert timestamp to HH:MM:SS format
+ *
+ * @param {Number} timestamp The value, in seconds, to format
+ *
+ * @returns {String} The formatted string
+ */
+export function toHHMMSS(timestamp) {
+  const hours = Math.floor(timestamp / HOUR);
+  const minutes = Math.floor((timestamp % HOUR) / MINUTE);
+  const seconds = Math.round(timestamp % MINUTE);
+
+  let result = hours === 0 ? '' : `${hours}:`;
+  result += minutes > 9 ? `${minutes}:` : `0${minutes}:`;
+  result += seconds > 9 ? `${seconds}` : `0${seconds}`;
+
+  return result;
+}
+
+/**
+ * Convert formatted time string to time in seconds
+ * Format: XhXmXs or X (seconds)
+ *
+ * @param {String} timeStr The value, in seconds, to format
+ *
+ * @returns {Number} The time in seconds
+ */
+export function parseFormattedTime(timeStr) {
+  const hours = parseInt(timeStr.match(/(\d*)h/g), 10) || 0;
+  const minutes = parseInt(timeStr.match(/(\d*)m/g), 10) || 0;
+  const seconds = parseInt(timeStr.match(/(\d*)s|^\d+$/g), 10) || 0;
+
+  return hours * HOUR + minutes * MINUTE + seconds;
 }
 
 /**

--- a/tests/integration/appLoads.js
+++ b/tests/integration/appLoads.js
@@ -10,6 +10,8 @@ import {
   YT_NAVBAR_ID,
   YT_LINK_CLASS,
   YT_CONTENT_RENDERER_CLASS,
+  YT_VIDEO_ID,
+  YT_VIDEO_TAG,
 } from '../../src/constants';
 import { VIDEO_URL } from './constants';
 
@@ -27,6 +29,8 @@ module.exports = {
     browser
       .assert.elementPresent(`#${YT_COMMENTS_ID}`)
       .assert.elementPresent(`#${YT_NAVBAR_ID}`)
+      .assert.elementPresent(`#${YT_VIDEO_ID}`)
+      .assert.elementPresent(`${YT_VIDEO_TAG}`)
       .assert.elementPresent(`.${YT_LINK_CLASS}`)
       .assert.elementPresent(`.${YT_CONTENT_RENDERER_CLASS}`)
   },

--- a/tests/util.test.js
+++ b/tests/util.test.js
@@ -1,4 +1,10 @@
-import { timeAgo, pluralize, abbreviateNumber } from '../src/util';
+import {
+  timeAgo,
+  pluralize,
+  abbreviateNumber,
+  parseFormattedTime,
+  toHHMMSS,
+} from '../src/util';
 
 // Constants
 
@@ -55,5 +61,29 @@ describe('abbreviateNumber', () => {
     expect(abbreviateNumber(9999)).toBe('10.0k');
     expect(abbreviateNumber(99999)).toBe('100.0k');
     expect(abbreviateNumber(999990)).toBe('1000.0k');
+  });
+});
+
+describe('toHHMMSS', () => {
+  test('base tests', () => {
+    expect(toHHMMSS(0)).toBe('00:00');
+    expect(toHHMMSS(11)).toBe('00:11');
+    expect(toHHMMSS(MINUTE)).toBe('01:00');
+    expect(toHHMMSS(MINUTE * 60)).toBe('1:00:00');
+  });
+});
+
+describe('parseFormattedTime', () => {
+  test('base tests', () => {
+    expect(parseFormattedTime('2m30s')).toBe(150);
+    expect(parseFormattedTime('9001s')).toBe(9001);
+    expect(parseFormattedTime('9001')).toBe(9001);
+    expect(parseFormattedTime('1h1m')).toBe(MINUTE * 60 + MINUTE);
+    expect(parseFormattedTime('1h1s')).toBe(MINUTE * 60 + 1);
+    expect(parseFormattedTime('1m1s')).toBe(MINUTE + 1);
+  });
+
+  test('handle bad input', () => {
+    expect(parseFormattedTime('badinputs')).toBe(0);
   });
 });


### PR DESCRIPTION
Adds a way to go to the video timestamp that may be present in a submission's url (.../watch?t=\<***timestamp***\>). 